### PR TITLE
remove ChildProcess export from index.ts

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -9,7 +9,7 @@ export { Log } from './log';
 import * as module_util from './util';
 export const util = module_util;
 export { Requests, RequestsError } from './requests';
-export { Subprocess, SubprocessError, ChildProcess } from './subprocess';
+export { Subprocess, SubprocessError } from './subprocess';
 export { Api, RequestHandler, HttpAuthErr, HttpClientErr, HttpRedirect, Status } from './api';
 export { RestfulApi, RestfulReq, RestfulRes } from './restful-buffer-api/restful-api';
 export { RestfulHandler } from './restful-buffer-api/restful-handler';


### PR DESCRIPTION
In index.ts, we are exporting our custom `ChildProcess` interface from subprocess.ts even though it no longer exists. This PR would delete it from index.ts as well.

If there is anything that depends on `ChildProcess` being exported from here, this PR would break that as well. For that reason, I considered going back into subprocess.ts and defining `ChildProcess` as an alias of `child_process.ChildProcess`, like so: 

```typescript
export type ChildProcess = child_process.ChildProcess;
``` 

However, after peaking around our various codebases I don't see any instances where it is used, so we should be fine. (if this assumption is incorrect please let me know and I can make an accompanying PR on the other project).