### PR TITLE
Disallow unauthorized db certs

### DIFF
--- a/source/config.ts
+++ b/source/config.ts
@@ -31,7 +31,7 @@ export class Config {
   APP_NAME = 'test_app';
   LOG_LEVEL = LOG_LEVELS.info;
   LOG_DIRECTORY = '';
-  DB_HOST = '127.0.0.1';
+  DB_HOST = 'localhost';
   DB_PORT = 26257;
   DB_NAME = 'db_test';
   DB_USER = 'user_test';

--- a/source/db.ts
+++ b/source/db.ts
@@ -32,7 +32,7 @@ export class Db {
       min: 1,
       max: 100,
       ssl: config.DB_INSECURE ? undefined : {
-        rejectUnauthorized: true, // todo - this should say true?
+        rejectUnauthorized: true,
         checkServerIdentity: (host, cert) => host !== config.DB_HOST ? new Error(`Unexpected db host: ${host}, expected: ${config.DB_HOST}`) : undefined,
         ca: readFileSync(`${config.DB_CERTS_PATH}/ca.crt`).toString(),
         key: readFileSync(`${config.DB_CERTS_PATH}/client.${config.DB_USER}.key`).toString(),

--- a/source/db.ts
+++ b/source/db.ts
@@ -32,7 +32,7 @@ export class Db {
       min: 1,
       max: 100,
       ssl: config.DB_INSECURE ? undefined : {
-        rejectUnauthorized: false, // todo - this should say true?
+        rejectUnauthorized: true, // todo - this should say true?
         checkServerIdentity: (host, cert) => host !== config.DB_HOST ? new Error(`Unexpected db host: ${host}, expected: ${config.DB_HOST}`) : undefined,
         ca: readFileSync(`${config.DB_CERTS_PATH}/ca.crt`).toString(),
         key: readFileSync(`${config.DB_CERTS_PATH}/client.${config.DB_USER}.key`).toString(),


### PR DESCRIPTION
Rejects unauthorized db certs. Also changes default DB host from `127.0.0.1` to `localhost` to make flowcrypt-attester-ts happy (might make other repos unhappy though).

Resolves https://github.com/FlowCrypt/flowcrypt-node-modules/issues/11