### PR TITLE
Add anti-content-type-sniffing header to prevent Content Type Forcing

### DIFF
--- a/source/restful-buffer-api/restful-api.ts
+++ b/source/restful-buffer-api/restful-api.ts
@@ -73,6 +73,7 @@ export class RestfulApi extends Api<RestfulReq, RestfulRes> {
 
   protected fmtHandlerRes = ({ body, status, contentType }: RestfulRes, serverRes: ServerResponse): Buffer => {
     serverRes.statusCode = status;
+    serverRes.setHeader('X-Content-Type-Options', 'no-sniff');
     if (contentType) {
       serverRes.setHeader('content-type', contentType);
     } else if (body) {


### PR DESCRIPTION
Adds header to prevent Content Type Forcing vulnerabilities on old OS/browser combos.

I tested this with the Attester via the following command:

```
alex@kur:~/git/flowcrypt-attester-ts$ npm run devStartPublicApi &
alex@kur:~/git/flowcrypt-attester-ts$ curl -si http://local-flowcrypt.com:5006 | grep sniff
X-Content-Type-Options: no-sniff
```

Let me know if additional testing should be required