### PR TITLE
Prevent frame ancestors in Restful API responses

### DIFF
--- a/source/restful-buffer-api/restful-api.ts
+++ b/source/restful-buffer-api/restful-api.ts
@@ -74,6 +74,7 @@ export class RestfulApi extends Api<RestfulReq, RestfulRes> {
   protected fmtHandlerRes = ({ body, status, contentType }: RestfulRes, serverRes: ServerResponse): Buffer => {
     serverRes.statusCode = status;
     serverRes.setHeader('X-Content-Type-Options', 'no-sniff');
+    serverRes.setHeader('X-Frame-Options', 'DENY');
     if (contentType) {
       serverRes.setHeader('content-type', contentType);
     } else if (body) {


### PR DESCRIPTION
I don't know if this is okay, there might be situations where these need to be in frames. If that's the case, we'll need to think of a better way.

Otherwise, this works

Resolves https://github.com/FlowCrypt/flowcrypt-security/issues/99