### PR TITLE
Don't reflect user input on 404

### DIFF
--- a/source/restful-buffer-api/restful-api.ts
+++ b/source/restful-buffer-api/restful-api.ts
@@ -116,7 +116,8 @@ export class RestfulApi extends Api<RestfulReq, RestfulRes> {
   }
 
   protected fmtErr = (e: any): Buffer => {
-    return Buffer.from(JSON.stringify({ error: { message: String(e).replace(/^Error: /, '') } }));
+    const errMsg = String(e).replace(/^Error: /, '').replace(/unknown path .*/, 'unknown path');
+    return Buffer.from(JSON.stringify({ error: { message: errMsg } }));
   }
 
 }


### PR DESCRIPTION
This is to prevent reflecting user input that could be abused for phishing on flowcrypt.com/pub/something/anothersomething.

The 'exploit' is lackluster since it doesn't work with whitespace, but might as well just not reflect it.