### PR TITLE
Add Github Action to monitor for email addresses in comments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+on:
+  issue_comment:
+    types: [created, edited]
+  issues:
+    types: [opened, edited]
+jobs:
+  find_emails:
+    runs-on: ubuntu-latest
+    name: Check for emails in issue comments
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Scan comment
+      id: scan
+      uses: seisvelas/comment-email-address-alerts@v8
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We want to be aware of accidentally posting users' email addresses in comments. This GitHub action monitors for that.

This has already been tested on https://github.com/FlowCrypt/node-subprocess, where it works successfully.