### PR TITLE
remove www-authenticate realm header from http 401 response

### DIFF
--- a/source/api.ts
+++ b/source/api.ts
@@ -58,7 +58,6 @@ export class Api<REQ, RES> {
       }).catch((e) => {
         if (e instanceof HttpAuthErr) {
           response.statusCode = Status.UNAUTHORIZED;
-          response.setHeader('WWW-Authenticate', `Basic realm="${this.apiName}"`);
           e.stack = undefined;
         } else if (e instanceof HttpClientErr) {
           response.statusCode = e.statusCode;


### PR DESCRIPTION
This PR will remove www-authenticate header from an HTTP 401 response

close https://github.com/FlowCrypt/flowcrypt-attester-ts/issues/199